### PR TITLE
Replace material-dialogs with AppCompat AlertDialog

### DIFF
--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -32,7 +32,6 @@ dependencies {
     api deps.dexter
     api deps.coroutines.core
     api deps.coroutines.android
-    api deps.material_dialogs
     implementation deps.timber
 
     testImplementation deps.junit

--- a/storage/src/main/java/com/anggrayudi/storage/SimpleStorageHelper.kt
+++ b/storage/src/main/java/com/anggrayudi/storage/SimpleStorageHelper.kt
@@ -5,10 +5,10 @@ import android.content.Context
 import android.net.Uri
 import android.os.Bundle
 import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
 import androidx.documentfile.provider.DocumentFile
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
-import com.afollestad.materialdialogs.MaterialDialog
 import com.anggrayudi.storage.callback.FilePickerCallback
 import com.anggrayudi.storage.callback.FolderPickerCallback
 import com.anggrayudi.storage.callback.StorageAccessCallback
@@ -54,10 +54,10 @@ class SimpleStorageHelper {
     private fun init() {
         storage.storageAccessCallback = object : StorageAccessCallback {
             override fun onRootPathNotSelected(requestCode: Int, rootPath: String, rootStorageType: StorageType, uri: Uri) {
-                MaterialDialog(storage.context)
-                    .message(if (rootStorageType == StorageType.SD_CARD) R.string.ss_please_select_root_storage_sdcard else R.string.ss_please_select_root_storage_primary)
-                    .negativeButton()
-                    .positiveButton {
+                AlertDialog.Builder(storage.context)
+                    .setMessage(if (rootStorageType == StorageType.SD_CARD) R.string.ss_please_select_root_storage_sdcard else R.string.ss_please_select_root_storage_primary)
+                    .setNegativeButton(android.R.string.cancel) { _, _ -> }
+                    .setPositiveButton(android.R.string.ok) { _, _ ->
                         storage.requestStorageAccess(requestCodeStorageAccess, rootStorageType)
                     }.show()
             }
@@ -100,10 +100,10 @@ class SimpleStorageHelper {
                     onStoragePermissionDenied(requestCode)
                     return
                 }
-                MaterialDialog(storage.context)
-                    .message(R.string.ss_storage_access_denied_confirm)
-                    .negativeButton()
-                    .positiveButton {
+                AlertDialog.Builder(storage.context)
+                    .setMessage(R.string.ss_storage_access_denied_confirm)
+                    .setNegativeButton(android.R.string.cancel) { _, _ -> }
+                    .setPositiveButton(android.R.string.ok) { _, _ ->
                         openFolderPickerOnceGranted = true
                         storage.requestStorageAccess(requestCodeStorageAccess, storageType)
                     }.show()

--- a/storage/src/main/java/com/anggrayudi/storage/file/DocumentFileCompat.kt
+++ b/storage/src/main/java/com/anggrayudi/storage/file/DocumentFileCompat.kt
@@ -453,7 +453,7 @@ object DocumentFileCompat {
     @JvmStatic
     fun getStorageIds(context: Context): List<String> {
         val externalStoragePath = SimpleStorage.externalStoragePath
-        val storageIds = ContextCompat.getExternalFilesDirs(context, null).map {
+        val storageIds = ContextCompat.getExternalFilesDirs(context, null).filterNotNull().map {
             val path = it.path
             if (path.startsWith(externalStoragePath)) {
                 // Path -> /storage/emulated/0/Android/data/com.anggrayudi.storage.sample/files


### PR DESCRIPTION
This PR removes the material-dialogs dependency in the library by switching its uses to the AppCompat AlertDialog.

This has multiple benefits:

- Prevents classpath pollution for users of this library who do not use material-dialogs
- Reduces APK size for the abovementioned users
- Allows the dialogs shown by the library to follow the theming set up by the apps using it

Fixes #33 



<details>
<summary>Screenshots</summary>

API 29:

![screenshot-20210529-152938](https://user-images.githubusercontent.com/13348378/120066199-1d588c80-c093-11eb-94a2-d8784eb9521e.png)


</details>