### PR TITLE
Remove unnecessary read permission request when picking files

### DIFF
--- a/storage/src/main/java/com/anggrayudi/storage/SimpleStorage.kt
+++ b/storage/src/main/java/com/anggrayudi/storage/SimpleStorage.kt
@@ -219,20 +219,16 @@ class SimpleStorage private constructor(private val wrapper: ComponentWrapper) {
     @JvmOverloads
     fun openFilePicker(requestCode: Int = requestCodeFilePicker, allowMultiple: Boolean = false, vararg filterMimeTypes: String) {
         requestCodeFilePicker = requestCode
-        if (hasStorageReadPermission(context)) {
-            val intent = Intent(Intent.ACTION_OPEN_DOCUMENT)
-                .putExtra(Intent.EXTRA_ALLOW_MULTIPLE, allowMultiple)
-            if (filterMimeTypes.size > 1) {
-                intent.setType(MimeType.UNKNOWN)
-                    .putExtra(Intent.EXTRA_MIME_TYPES, filterMimeTypes)
-            } else {
-                intent.type = filterMimeTypes.firstOrNull() ?: MimeType.UNKNOWN
-            }
-            if (!wrapper.startActivityForResult(intent, requestCode))
-                filePickerCallback?.onActivityHandlerNotFound(requestCode, intent)
+        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT)
+            .putExtra(Intent.EXTRA_ALLOW_MULTIPLE, allowMultiple)
+        if (filterMimeTypes.size > 1) {
+            intent.setType(MimeType.UNKNOWN)
+                .putExtra(Intent.EXTRA_MIME_TYPES, filterMimeTypes)
         } else {
-            filePickerCallback?.onStoragePermissionDenied(requestCode, null)
+            intent.type = filterMimeTypes.firstOrNull() ?: MimeType.UNKNOWN
         }
+        if (!wrapper.startActivityForResult(intent, requestCode))
+            filePickerCallback?.onActivityHandlerNotFound(requestCode, intent)
     }
 
     private fun handleActivityResultForStorageAccess(requestCode: Int, uri: Uri) {
@@ -361,11 +357,7 @@ class SimpleStorage private constructor(private val wrapper: ComponentWrapper) {
                 if (files.isEmpty()) {
                     fileReceiverCallback?.onNonFileReceived(intent)
                 } else {
-                    if (files.all { it.canRead() }) {
-                        fileReceiverCallback?.onFileReceived(files)
-                    } else {
-                        fileReceiverCallback?.onStoragePermissionDenied(files)
-                    }
+                    fileReceiverCallback?.onFileReceived(files)
                 }
             }
         }

--- a/storage/src/main/java/com/anggrayudi/storage/SimpleStorageHelper.kt
+++ b/storage/src/main/java/com/anggrayudi/storage/SimpleStorageHelper.kt
@@ -155,10 +155,6 @@ class SimpleStorageHelper {
                 override fun onNonFileReceived(intent: Intent) {
                     callback?.onNonFileReceived(intent)
                 }
-
-                override fun onStoragePermissionDenied(files: List<DocumentFile>) {
-                    requestStoragePermission { if (it) callback?.onFileReceived(files) else reset() }
-                }
             }
         }
 

--- a/storage/src/main/java/com/anggrayudi/storage/callback/FileReceiverCallback.kt
+++ b/storage/src/main/java/com/anggrayudi/storage/callback/FileReceiverCallback.kt
@@ -11,5 +11,4 @@ interface FileReceiverCallback {
 
     fun onFileReceived(files: List<DocumentFile>)
     fun onNonFileReceived(intent: Intent)
-    fun onStoragePermissionDenied(files: List<DocumentFile>)
 }


### PR DESCRIPTION
Is read permission really needed when picking files via SAF? Files picked by the user through SAF will be readable anyway by the requesting app.

PS: Github diff view in this commit is garbage.