### PR TITLE
Fix case where onRootPathNotSelected is called eventhough expectedStorageType is selectedStorageType 

### DIFF
--- a/storage/src/main/java/com/anggrayudi/storage/SimpleStorage.kt
+++ b/storage/src/main/java/com/anggrayudi/storage/SimpleStorage.kt
@@ -292,7 +292,7 @@ class SimpleStorage private constructor(private val wrapper: ComponentWrapper) {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
                     val sm = context.getSystemService(Context.STORAGE_SERVICE) as StorageManager
                     @Suppress("DEPRECATION")
-                    sm.storageVolumes.firstOrNull { it.isRemovable }?.createAccessIntent(null)?.let {
+                    sm.storageVolumes.firstOrNull { !it.isPrimary }?.createAccessIntent(null)?.let {
                         if (!wrapper.startActivityForResult(it, requestCode)) {
                             storageAccessCallback?.onActivityHandlerNotFound(requestCode, it)
                         }


### PR DESCRIPTION
I am testing this library to decide if I will use it in a bigger project and noticed an edge case that was not handled correctly.

Hardware setup:
 - Android device with Oreo (API 24) (should happen on API Levels 23-28)
 - physical sdcard that is formatted as "internal" storage
 - additional external mass storage device such as an USB stick or external harddrive attached to smartphone

Steps to reproduce:
 1. Grant Manifest Storage Permissions
 2. Request Storage Access and specify SD_CARD for initial and expected StorageType `storage.requestStorageAccess(REQUEST_CODE_STORAGE_ACCESS, StorageType.SD_CARD, StorageType.SD_CARD)`
 3. In the following FolderPicker choose a _subdirectory_ within the external mass storage device
 4. onRootPathNotSelected gets called with expectedStorageType and selectedStorageType both being SD_CARD

I modified one line of the sample app on this branch to reproduce the issue:
https://github.com/stefanoberdoerfer/SimpleStorage/tree/reproBranch

The cause of this issue is that the StorageManager returns two `storageVolumes`. The first one is the physical sdcard that is a the same time a `removable` volume and the `primary` one (because sd card is formatted as "internal").
The second volume is the mass storage device really want to address. It is also `removeable` but not `primary`.