### PR TITLE
Fixed destination file extension by mimeType in copyFolderTo()

### DIFF
--- a/storage/src/main/java/com/anggrayudi/storage/file/DocumentFileExt.kt
+++ b/storage/src/main/java/com/anggrayudi/storage/file/DocumentFileExt.kt
@@ -1999,7 +1999,7 @@ private fun DocumentFile.copyFolderTo(
                 continue
             }
 
-            targetFile = targetFolder.makeFile(context, filename, sourceFile.type, CreateMode.REUSE)
+            targetFile = targetFolder.makeFile(context, filename, mimeType = null, CreateMode.REUSE)
             if (targetFile != null && targetFile.length() > 0) {
                 conflictedFiles.add(FolderCallback.FileConflict(sourceFile, targetFile))
                 continue


### PR DESCRIPTION
Removed passing the `mimeType` to `makeFile()` for files when copying with `Document File.copy Folder To()`, which is why the extension of the copied files changed (because in system file`MimeTypeMap.java` by this `mimeType` has no exact match with the extension, e.g. "text/html" corresponds to "htm", which led to copying the file "file.html " in "file.html.htm ").  
With this change, the file extension and its name do not change, which is required.