### PR TITLE
Fix in cleanupRedundantUriPermissions

### DIFF
--- a/storage/src/main/java/com/anggrayudi/storage/SimpleStorage.kt
+++ b/storage/src/main/java/com/anggrayudi/storage/SimpleStorage.kt
@@ -51,6 +51,8 @@ class SimpleStorage private constructor(private val wrapper: ComponentWrapper) {
         (wrapper as FragmentWrapper).storage = this
     }
 
+    var isCleanupRedundantUriPermissions: Boolean = true
+
     var storageAccessCallback: StorageAccessCallback? = null
 
     var folderPickerCallback: FolderPickerCallback? = null
@@ -545,7 +547,9 @@ class SimpleStorage private constructor(private val wrapper: ComponentWrapper) {
     private fun saveUriPermission(root: Uri) = try {
         val writeFlags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
         context.contentResolver.takePersistableUriPermission(root, writeFlags)
-        cleanupRedundantUriPermissions(context.applicationContext)
+        if (isCleanupRedundantUriPermissions) {
+            cleanupRedundantUriPermissions(context.applicationContext)
+        }
         true
     } catch (e: SecurityException) {
         false


### PR DESCRIPTION
Has been added a separate setting  `isCleanupRedundantUriPermissions: Boolean` (default `true`). 
If `isCleanupRedundantUriPermissions==true`, then after selecting the directory in SAF, the `SimpleStorage.cleanupRedundantUriPermissions()` method is executed (current behavior), otherwise it's not executed.

For example:

- `/storage/emulated/0/Repositories` - parent directory
- `/storage/emulated/0/Repositories/Test1` - child directory

`cleanupRedundantUriPermissions()` leaves access (persistable uri) only to the parent directories, and removing access to the "unnecessary" child directories. 

I couldn't figure out the reason, but if you grant access to both the parent and child directories in SAF (access to the child, respectively, will be removed using `cleanupRedundantUriPermissions()`), then access to the child directory will not be checked after that (checks in different ways). Until you manually delete the granted permissions in the app system settings, and in SAF grant access ONLY to the child. If do not call `cleanupRedundantUriPermissions()`, then this does not happen, and mechanism works as required.