### PR TITLE
Support storage ID formats for NTFS and ChromeOS

### DIFF
--- a/storage/src/main/java/com/anggrayudi/storage/extension/TextExt.kt
+++ b/storage/src/main/java/com/anggrayudi/storage/extension/TextExt.kt
@@ -72,7 +72,7 @@ fun String.parent(): String {
     }
     val parentPath = folderTree.take(folderTree.size - 1).joinToString("/", "/")
     return if (parentPath.startsWith(SimpleStorage.externalStoragePath)
-        || parentPath.matches(Regex("/storage/[A-Z0-9]{4}-[A-Z0-9]{4}(.*?)"))
+        || parentPath.matches(Regex("/storage/[A-Z0-9-]+(.*?)"))
         || Build.VERSION.SDK_INT < 21 && parentPath.startsWith(SimpleStorage.KITKAT_SD_CARD_PATH)
     ) {
         parentPath

--- a/storage/src/main/java/com/anggrayudi/storage/file/DocumentFileCompat.kt
+++ b/storage/src/main/java/com/anggrayudi/storage/file/DocumentFileCompat.kt
@@ -62,7 +62,7 @@ object DocumentFileCompat {
     val FILE_NAME_DUPLICATION_REGEX_WITHOUT_EXTENSION = Regex("(.*?) \\(\\d+\\)")
 
     @RestrictTo(RestrictTo.Scope.LIBRARY)
-    val SD_CARD_STORAGE_ID_REGEX = Regex("[A-Z0-9]{4}-[A-Z0-9]{4}")
+    val SD_CARD_STORAGE_ID_REGEX = Regex("[A-Z0-9-]+")
 
     @RestrictTo(RestrictTo.Scope.LIBRARY)
     val SD_CARD_STORAGE_PATH_REGEX = Regex("/storage/$SD_CARD_STORAGE_ID_REGEX(.*?)")


### PR DESCRIPTION
I noticed that there are some storage IDs that don't match the format `ABCD-1234`. For example, a USB drive with NTFS has a storage ID format consisting of a 16-digit hex string, like `A0E69251E6922814`. Additionally, all external storages on ChromeOS, regardless of the filesystem they use, have a storage ID format that consists of a 40-digit hex string, such as `BB146539D141DC32010CB1AD374464444024627A`. Since I'm uncertain if there are other storage IDs with varying lengths, I've updated the regex to now accept any strings containing a combination of hex characters and dashes.
