### PR TITLE
Remove BuildConfig from release artifacts

### DIFF
--- a/storage/build.gradle.kts
+++ b/storage/build.gradle.kts
@@ -65,4 +65,5 @@ dependencies {
 
 afterEvaluate {
     tasks.findByName("generateReleaseBuildConfig")?.enabled = false
+    tasks.findByName("generateDebugBuildConfig")?.enabled = false
 }

--- a/storage/build.gradle.kts
+++ b/storage/build.gradle.kts
@@ -62,3 +62,7 @@ dependencies {
   testImplementation(libs.powermock.junit4)
   testImplementation(libs.powermock.api.mockito)
 }
+
+afterEvaluate {
+    tasks.findByName("generateReleaseBuildConfig")?.enabled = false
+}

--- a/storage/src/main/java/com/anggrayudi/storage/SimpleStorage.kt
+++ b/storage/src/main/java/com/anggrayudi/storage/SimpleStorage.kt
@@ -657,23 +657,23 @@ class SimpleStorage private constructor(private val wrapper: ComponentWrapper) {
     }
 
   companion object {
-
+    const val LIBRARY_PACKAGE_NAME = "com.anggrayudi.storage"
     private const val KEY_REQUEST_CODE_STORAGE_ACCESS =
-      BuildConfig.LIBRARY_PACKAGE_NAME + ".requestCodeStorageAccess"
+      LIBRARY_PACKAGE_NAME + ".requestCodeStorageAccess"
     private const val KEY_REQUEST_CODE_FOLDER_PICKER =
-      BuildConfig.LIBRARY_PACKAGE_NAME + ".requestCodeFolderPicker"
+      LIBRARY_PACKAGE_NAME + ".requestCodeFolderPicker"
     private const val KEY_REQUEST_CODE_FILE_PICKER =
-      BuildConfig.LIBRARY_PACKAGE_NAME + ".requestCodeFilePicker"
+      LIBRARY_PACKAGE_NAME + ".requestCodeFilePicker"
     private const val KEY_REQUEST_CODE_CREATE_FILE =
-      BuildConfig.LIBRARY_PACKAGE_NAME + ".requestCodeCreateFile"
+      LIBRARY_PACKAGE_NAME + ".requestCodeCreateFile"
     private const val KEY_REQUEST_CODE_FRAGMENT_PICKER =
-      BuildConfig.LIBRARY_PACKAGE_NAME + ".requestCodeFragmentPicker"
+      LIBRARY_PACKAGE_NAME + ".requestCodeFragmentPicker"
     private const val KEY_EXPECTED_STORAGE_TYPE_FOR_ACCESS_REQUEST =
-      BuildConfig.LIBRARY_PACKAGE_NAME + ".expectedStorageTypeForAccessRequest"
+      LIBRARY_PACKAGE_NAME + ".expectedStorageTypeForAccessRequest"
     private const val KEY_EXPECTED_BASE_PATH_FOR_ACCESS_REQUEST =
-      BuildConfig.LIBRARY_PACKAGE_NAME + ".expectedBasePathForAccessRequest"
+      LIBRARY_PACKAGE_NAME + ".expectedBasePathForAccessRequest"
     private const val KEY_LAST_VISITED_FOLDER =
-      BuildConfig.LIBRARY_PACKAGE_NAME + ".lastVisitedFolder"
+      LIBRARY_PACKAGE_NAME + ".lastVisitedFolder"
     private const val TAG = "SimpleStorage"
 
     private const val DEFAULT_REQUEST_CODE_STORAGE_ACCESS: Int = 1

--- a/storage/src/main/java/com/anggrayudi/storage/SimpleStorageHelper.kt
+++ b/storage/src/main/java/com/anggrayudi/storage/SimpleStorageHelper.kt
@@ -13,6 +13,7 @@ import androidx.activity.ComponentActivity
 import androidx.appcompat.app.AlertDialog
 import androidx.documentfile.provider.DocumentFile
 import androidx.fragment.app.Fragment
+import com.anggrayudi.storage.SimpleStorage.Companion.LIBRARY_PACKAGE_NAME
 import com.anggrayudi.storage.callback.CreateFileCallback
 import com.anggrayudi.storage.callback.FilePickerCallback
 import com.anggrayudi.storage.callback.FileReceiverCallback
@@ -452,10 +453,10 @@ class SimpleStorageHelper {
     const val TYPE_FOLDER_PICKER = 2
 
     private const val KEY_OPEN_FOLDER_PICKER_ONCE_GRANTED =
-      BuildConfig.LIBRARY_PACKAGE_NAME + ".pickerToOpenOnceGranted"
+      LIBRARY_PACKAGE_NAME + ".pickerToOpenOnceGranted"
     private const val KEY_ORIGINAL_REQUEST_CODE =
-      BuildConfig.LIBRARY_PACKAGE_NAME + ".originalRequestCode"
-    private const val KEY_FILTER_MIME_TYPES = BuildConfig.LIBRARY_PACKAGE_NAME + ".filterMimeTypes"
+      LIBRARY_PACKAGE_NAME + ".originalRequestCode"
+    private const val KEY_FILTER_MIME_TYPES = LIBRARY_PACKAGE_NAME + ".filterMimeTypes"
 
     @JvmStatic
     fun redirectToSystemSettings(context: Context) {

--- a/storage/src/test/java/com/anggrayudi/storage/SimpleStorageTest.kt
+++ b/storage/src/test/java/com/anggrayudi/storage/SimpleStorageTest.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.UriPermission
 import android.net.Uri
 import android.os.Build
+import com.anggrayudi.storage.SimpleStorage.Companion.LIBRARY_PACKAGE_NAME
 import io.mockk.*
 import java.io.File
 import kotlin.concurrent.thread
@@ -25,7 +26,7 @@ class SimpleStorageTest {
 
   private val context =
     mockk<Context> {
-      val dataDirectoryPath = "/data/user/0/${BuildConfig.LIBRARY_PACKAGE_NAME}"
+      val dataDirectoryPath = "/data/user/0/${LIBRARY_PACKAGE_NAME}"
       val fileDir = File("$dataDirectoryPath/files")
       every { filesDir } returns fileDir
       every { dataDir } returns File(dataDirectoryPath)

--- a/storage/src/test/java/com/anggrayudi/storage/file/DocumentFileCompatTest.kt
+++ b/storage/src/test/java/com/anggrayudi/storage/file/DocumentFileCompatTest.kt
@@ -2,7 +2,7 @@ package com.anggrayudi.storage.file
 
 import android.content.Context
 import android.os.Environment
-import com.anggrayudi.storage.BuildConfig
+import com.anggrayudi.storage.SimpleStorage.Companion.LIBRARY_PACKAGE_NAME
 import com.anggrayudi.storage.file.StorageId.PRIMARY
 import io.mockk.every
 import io.mockk.mockk
@@ -21,7 +21,7 @@ class DocumentFileCompatTest {
 
   private val context =
     mockk<Context> {
-      val dataDirectoryPath = "/data/user/0/${BuildConfig.LIBRARY_PACKAGE_NAME}"
+      val dataDirectoryPath = "/data/user/0/${LIBRARY_PACKAGE_NAME}"
       val fileDir = File("$dataDirectoryPath/files")
       every { filesDir } returns fileDir
       every { dataDir } returns File(dataDirectoryPath)


### PR DESCRIPTION
It's standard for JVM/Gradle dependencies to omit BuildConfig from the artifacts as this usually conflicts with the BuildConfig the imports in the using projects. This shouldn't result any issues as the BuildConfig is not used specifically for some functions.